### PR TITLE
Change CentOS repo link

### DIFF
--- a/ansible/tasks/origin-311.yml
+++ b/ansible/tasks/origin-311.yml
@@ -4,7 +4,7 @@
     content: |
       [centos-openshift-origin311]
       name=CentOS OpenShift Origin
-      baseurl=http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin311/
+      baseurl=http://vault.centos.org/centos/7/paas/x86_64/openshift-origin311/
       enabled=1
       gpgcheck=1
       gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-PaaS


### PR DESCRIPTION
Old mirror links do not work anymore, need to change to vault.